### PR TITLE
disable beaker acceptance testing

### DIFF
--- a/.sync.yaml
+++ b/.sync.yaml
@@ -1,0 +1,2 @@
+.github/workflows/ci.yml:
+  acceptance_tests: false


### PR DESCRIPTION
add `.sync.yaml` to prepare for the next module_sync run to disable acceptance testing for the moment