### PR TITLE
Drop puppet, update openvox minimum version to 8.19

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,12 +68,8 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">7.0.0 < 9.0.0"
-    },
-    {
       "name": "openvox",
-      "version_requirement": ">7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.19.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
* drop support for puppet as discussed in [1]
* update openvox minimum version to 8.19.0 as discussed in [2] and [3]

[1] https://github.com/voxpupuli/community-triage/issues/59
[2] https://github.com/voxpupuli/community-triage/issues/60
[3] https://github.com/voxpupuli/modulesync_config/pull/978#discussion_r2232830327
