### PR TITLE
WIP fix: https://github.com/voxpupuli/puppet-wildfly/issues/355

### DIFF
--- a/templates/wildfly.systemd.conf.epp
+++ b/templates/wildfly.systemd.conf.epp
@@ -1,7 +1,9 @@
 <% $config = $wildfly::mode? { 'domain' => "${wildfly::domain_config} --host-config ${wildfly::host_config}", default => $wildfly::config } %>
 
 # The configuration you want to run
-WILDFLY_CONFIG="'<%= $config %> -P <%= $wildfly::dirname %>/jboss.properties'"
+WILDFLY_CONFIG=<%= $config %> 
+
+WILDFLY_PROPERTIES=<%= $wildfly::dirname %>/jboss.properties
 
 # The mode you want to run
 WILDFLY_MODE=<%= $wildfly::mode %>

--- a/templates/wildfly.systemd.service.epp
+++ b/templates/wildfly.systemd.service.epp
@@ -9,7 +9,7 @@ User=<%= $wildfly::user %>
 Group=<%= $wildfly::group %>
 EnvironmentFile=/etc/wildfly/wildfly.conf
 LimitNOFILE=102642
-ExecStart=<%= $wildfly::dirname %>/bin/launch.sh ${WILDFLY_MODE} ${WILDFLY_CONFIG}
+ExecStart=<%= $wildfly::dirname %>/bin/launch.sh ${WILDFLY_MODE} ${WILDFLY_CONFIG} -P ${WILDFLY_PROPERTIES}
 Restart=always
 RestartSec=20
 StandardOutput=null


### PR DESCRIPTION
#### Pull Request (PR) description

When starting through systemd, serveral parameters where grouped by quotes, like '/opt/wildfly/bin/launch.sh standalone 'standalone.xml -P jboss.properties' which is results in

    WFLYSRV0239: Aborting with exit code 1

. Quoting is only applied to file paths with this fix.

#### This Pull Request (PR) fixes the following issues

Fixes #355 